### PR TITLE
fix(build): try known workarounds when luarocks build fails

### DIFF
--- a/lua/luarocks-nvim/build.lua
+++ b/lua/luarocks-nvim/build.lua
@@ -123,6 +123,15 @@ local steps = {
 			}
 			vim.list_extend(cmd, luarocks_args or {})
 			local error_code, stdout, stderr = run_job(cmd)
+			-- some known workarounds for better user experience
+			local next_try_args = {
+				{ "--with-lua-include=/usr/include" }, -- arch linux
+			}
+			-- while error_code ~= 0 try the workarounds
+			while error_code ~= 0 and #next_try_args > 0 do
+				error_code, _, _ = run_job(vim.list_extend(vim.deepcopy(cmd), next_try_args[1]))
+				table.remove(next_try_args, 1)
+			end
 			assert(error_code == 0, string.format("Failed to install luarocks: %s\n%s", stdout, stderr))
 		end,
 	},


### PR DESCRIPTION
The `./configure` script and Arch Linux folder structure just don't get along nicely yielding an error message as follows.

```txt
❌ Performing luarocks `./configure` if Unix systems
...hare/nvim/lazy/luarocks.nvim/lua/luarocks-nvim/build.lua:126: Failed to install luarocks: 
Configuring LuaRocks version dev...

Lua interpreter found: /sbin/luajit
Checking if /sbin/luajit is Lua version 5.1... yes
lua.h for Lua 5.1 not found (tried //include/lua/5.1/lua.h //include/lua5.1/lua.h //include/lua-5.1/lua.h //include/lua51/lua.h //include/lua.h //include/luajit-2.1/lua.h)

If the development files for Lua (headers and libraries)
are installed in your system, you may need to use the
--with-lua or --with-lua-include flags to specify their location.

If those files are not yet installed, you need to install
them using the appropriate method for your operating system.

Run ./configure --help for details on flags.

configure failed.
```

This error has been reported on multiple places and it is affecting not small number of peoples so we've decided to make an official workaround.

---

If you liked this code better cuz it's more verbose, let me know.

![image](https://github.com/vhyrro/luarocks.nvim/assets/41065736/39fa49a9-b7fe-42ad-b198-ccf93d6191a5)
