### PR TITLE
feature: pass variables to luarocks install

### DIFF
--- a/lua/luarocks-nvim/init.lua
+++ b/lua/luarocks-nvim/init.lua
@@ -38,7 +38,7 @@ return {
 			end
 
 			-- We have requested rocks so ensure they are installed
-			rocks.ensure(opts.rocks)
+			rocks.ensure(opts.rocks, opts.luarocks_install_vars)
 		else
 			-- We haven't built yet so register the rocks
 			-- to be installed after build finishes

--- a/lua/luarocks-nvim/rocks.lua
+++ b/lua/luarocks-nvim/rocks.lua
@@ -1,7 +1,7 @@
 local paths = require("luarocks-nvim.paths")
 local notify = require("luarocks-nvim.notify")
 
-local function install(rocks)
+local function install(rocks, luarocks_install_vars)
 	local file, error = io.open(paths.rockspec, "w+")
 	assert(file, "[luarocks] Failed to write rockspec file " .. (error or ""))
 
@@ -22,21 +22,25 @@ build = { type = "builtin" }
 
 	local record = notify.info({ "⌛ Installing rocks:\n", table.concat(rocks, ",") })
 
-	local output = vim.fn.system({
+	local cmd = {
 		paths.luarocks,
 		"install",
 		"--lua-version=5.1",
 		"--server='https://nvim-neorocks.github.io/rocks-binaries/'",
 		"--deps-only",
 		paths.rockspec,
-	})
+	}
+
+	vim.list_extend(cmd, luarocks_install_vars or {})
+
+	local output = vim.fn.system(cmd)
 
 	assert(vim.v.shell_error == 0, "[luarocks] Failed to install from rockspec\n" .. output)
 
 	notify.info("✅ Installed rocks", record)
 end
 
-local function ensure(rocks)
+local function ensure(rocks, luarocks_install_vars)
 	-- There are no rocks requests
 	if not rocks or #rocks == 0 then
 		return
@@ -64,7 +68,7 @@ local function ensure(rocks)
 	end
 
 	if #missing_rocks ~= 0 then
-		install(rocks)
+		install(rocks, luarocks_install_vars)
 	end
 end
 


### PR DESCRIPTION
Resolves #18 

This change adds `luarocks_install_vars` option to allow passing variables to `luarocks install`.

Example:
```lua
{
  "vhyrro/luarocks.nvim"
  priority = 1000,
  config = true,
  opts = {
    rocks = { "lua-curl" }
    luarocks_install_vars = { "CURL_DIR=" .. (os.getenv("CURL_DIR") or "/usr/local") }
  }
}
```