### PR TITLE
feature: added  option `luarocks_install_args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To install a set of rocks (with the ability to add version constraints) use the 
   opts = {
     rocks = { "fzy", "pathlib.nvim ~> 1.0" }, -- specifies a list of rocks to install
     -- luarocks_build_args = { "--with-lua=/my/path" }, -- extra options to pass to luarocks's configuration script
+    -- luarocks_install_args = { "LUA_INCDIR=/usr/include/luajit-2.1" }, -- extra options to use when installing rocks
   },
 }
 ```

--- a/lua/luarocks-nvim/init.lua
+++ b/lua/luarocks-nvim/init.lua
@@ -38,11 +38,11 @@ return {
 			end
 
 			-- We have requested rocks so ensure they are installed
-			rocks.ensure(opts.rocks)
+			rocks.ensure(opts.rocks, opts.luarocks_install_args)
 		else
 			-- We haven't built yet so register the rocks
 			-- to be installed after build finishes
-			build.ensure_rocks_after_build(opts.rocks, opts.luarocks_build_args)
+			build.ensure_rocks_after_build(opts.rocks, opts.luarocks_build_args, opts.luarocks_install_args)
 		end
 	end,
 }


### PR DESCRIPTION
This fixes the problem in arch linux where it picks up the `lua.h` from system lua version `5.4` instead of the included in `luajit`.